### PR TITLE
Support var injection in job_vars from another role than BAG

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -5,3 +5,5 @@ schedule_stop_after_start: disabled
 
 current_state: unknown
 desired_state: unknown
+
+dynamic_job_vars: {}

--- a/tasks/handle-action-destroy.yaml
+++ b/tasks/handle-action-destroy.yaml
@@ -1,5 +1,17 @@
 ---
 - name: Call Ansible Tower job-runner to destroy {{ anarchy_subject_name }}
+  vars:
+    action_job_vars:
+      ACTION: destroy
+      __meta__:
+        callback:
+          token: "{{ anarchy_action_callback_token }}"
+          url: "{{ anarchy_action_callback_url }}"
+        deployer:
+          entry_point: ansible/destroy.yml
+          timeout: 0
+        tower:
+          action: destroy
   uri:
     url: https://{{ babylon_tower.hostname }}/api/v2/job_templates/job-runner/launch/
     url_username: "{{ babylon_tower.user }}"
@@ -15,14 +27,8 @@
         job_vars: >-
           {{ vars.anarchy_subject.vars.job_vars | default({})
            | combine(vars.anarchy_governor.vars.job_vars, recursive=True)
-           | combine({
-               'ACTION': 'destroy',
-               '__meta__': {
-                 'callback': {'token': anarchy_action_callback_token, 'url': anarchy_action_callback_url},
-                 'deployer': {'entry_point': 'ansible/destroy.yml', 'timeout': 0},
-                 'tower': {'action': 'destroy'}
-               }
-             }, recursive=True)
+           | combine(dynamic_job_vars, recursive=True)
+           | combine(action_job_vars, recursive=True)
           }}
   register: r_api_response
   # FIXME - Handle API errors

--- a/tasks/handle-action-provision.yaml
+++ b/tasks/handle-action-provision.yaml
@@ -1,5 +1,17 @@
 ---
 - name: Call Ansible Tower job-runner to provision {{ anarchy_subject_name }}
+  vars:
+    action_job_vars:
+      ACTION: provision
+      __meta__:
+        callback:
+          token: "{{ anarchy_action_callback_token }}"
+          url: "{{ anarchy_action_callback_url }}"
+        deployer:
+          entry_point: ansible/main.yml
+          timeout: 0
+        tower:
+          action: provision
   uri:
     url: https://{{ babylon_tower.hostname }}/api/v2/job_templates/job-runner/launch/
     url_username: "{{ babylon_tower.user }}"
@@ -15,14 +27,8 @@
         job_vars: >-
           {{ vars.anarchy_subject.vars.job_vars | default({})
            | combine(vars.anarchy_governor.vars.job_vars, recursive=True)
-           | combine({
-               'ACTION': 'provision',
-               '__meta__': {
-                 'callback': {'token': anarchy_action_callback_token, 'url': anarchy_action_callback_url},
-                 'deployer': {'entry_point': 'ansible/main.yml', 'timeout': 0},
-                 'tower': {'action': 'provision'}
-               }
-             }, recursive=True)
+           | combine(dynamic_job_vars, recursive=True)
+           | combine(action_job_vars, recursive=True)
           }}
   register: r_api_response
   # FIXME - Handle API errors

--- a/tasks/handle-action-start.yaml
+++ b/tasks/handle-action-start.yaml
@@ -1,5 +1,17 @@
 ---
 - name: Call Ansible Tower job-runner to start {{ anarchy_subject_name }}
+  vars:
+    action_job_vars:
+      ACTION: start
+      __meta__:
+        callback:
+          token: "{{ anarchy_action_callback_token }}"
+          url: "{{ anarchy_action_callback_url }}"
+        deployer:
+          entry_point: ansible/lifecycle_entry_point.yml
+          timeout: 0
+        tower:
+          action: start
   uri:
     url: https://{{ babylon_tower.hostname }}/api/v2/job_templates/job-runner/launch/
     url_username: "{{ babylon_tower.user }}"
@@ -16,14 +28,8 @@
         job_vars: >-
           {{ vars.anarchy_subject.vars.job_vars | default({})
            | combine(vars.anarchy_governor.vars.job_vars, recursive=True)
-           | combine({
-               'ACTION': 'start',
-               '__meta__': {
-                 'callback': {'token': anarchy_action_callback_token, 'url': anarchy_action_callback_url},
-                 'deployer': {'entry_point': 'ansible/lifecycle_entry_point.yml', 'timeout': 0},
-                 'tower': {'action': 'start'}
-               }
-             }, recursive=True)
+           | combine(dynamic_job_vars, recursive=True)
+           | combine(action_job_vars, recursive=True)
           }}
   register: r_api_response
   # FIXME - Handle API errors

--- a/tasks/handle-action-stop.yaml
+++ b/tasks/handle-action-stop.yaml
@@ -1,5 +1,17 @@
 ---
 - name: Call Ansible Tower job-runner to stop {{ anarchy_subject_name }}
+  vars:
+    action_job_vars:
+      ACTION: stop
+      __meta__:
+        callback:
+          token: "{{ anarchy_action_callback_token }}"
+          url: "{{ anarchy_action_callback_url }}"
+        deployer:
+          entry_point: ansible/lifecycle_entry_point.yml
+          timeout: 0
+        tower:
+          action: stop
   uri:
     url: https://{{ babylon_tower.hostname }}/api/v2/job_templates/job-runner/launch/
     url_username: "{{ babylon_tower.user }}"
@@ -16,14 +28,8 @@
         job_vars: >-
           {{ vars.anarchy_subject.vars.job_vars | default({})
            | combine(vars.anarchy_governor.vars.job_vars, recursive=True)
-           | combine({
-               'ACTION': 'stop',
-               '__meta__': {
-                 'callback': {'token': anarchy_action_callback_token, 'url': anarchy_action_callback_url},
-                 'deployer': {'entry_point': 'ansible/lifecycle_entry_point.yml', 'timeout': 0},
-                 'tower': {'action': 'stop'}
-               }
-             }, recursive=True)
+           | combine(dynamic_job_vars, recursive=True)
+           | combine(action_job_vars, recursive=True)
           }}
   register: r_api_response
   # FIXME - Handle API errors


### PR DESCRIPTION
This commit, if applied, introduces a new variable that can be used in other
roles than BAG to update the `job_vars` dictionary sent down to tower.

   dynamic_job_vars

- Also use vars YAML with _params, instead of inline dictionary in JSON format