### PR TITLE
Set uuid for subject on create event

### DIFF
--- a/tasks/handle-event-create.yaml
+++ b/tasks/handle-event-create.yaml
@@ -11,3 +11,6 @@
     spec:
       vars:
         current_state: provision-pending
+        job_vars:
+          uuid: >-
+            {{ vars.anarchy_subject.vars.job_vars.uuid | default((2*127) | random | to_uuid) }}


### PR DESCRIPTION
This will set uuid for the AnarchySubject job vars if it is not set.