### PR TITLE
Fix status handling

### DIFF
--- a/tasks/handle-action-status-complete.yaml
+++ b/tasks/handle-action-status-complete.yaml
@@ -3,6 +3,7 @@
   anarchy_subject_update:
     spec:
       vars:
+        check_status_state: successful
         status_data: '{{ anarchy_action_callback_data.data | default(omit, true) }}'
         status_messages: '{{ anarchy_action_callback_data.messages | default(omit, true) }}'
     status:

--- a/tasks/handle-event-update.yaml
+++ b/tasks/handle-event-update.yaml
@@ -25,14 +25,13 @@
       action: "{{ _action }}"
 
 - name: Run action based on current_state and desired_state
-  when: check_status | default(false) | bool
+  when: check_status_state == 'pending'
   block:
   - name: Set {{ anarchy_subject_name }} check_status to false
     anarchy_subject_update:
       skip_update_processing: true
       spec:
         vars:
-          check_status: false
           check_status_state: pending
 
   - name: Schedule status check for {{ anarchy_subject_name }}

--- a/tasks/run-status.yaml
+++ b/tasks/run-status.yaml
@@ -22,4 +22,8 @@
       }}
   include_tasks:
     file: run-tower-job.yaml
+
+- name: Schedule check for status of {{ anarchy_subject_name }}
+  anarchy_continue_action:
+    after: "{{ tower_job_check_interval }}"
 ...


### PR DESCRIPTION
The logic is to schedule a status check when check_status_state is "pending" from there it transitions to "running" and from there to either to "successful", "failed" or "canceled".