### PR TITLE
Fix delete when not provisioned

### DIFF
--- a/tasks/handle-event-delete.yaml
+++ b/tasks/handle-event-delete.yaml
@@ -1,5 +1,11 @@
 ---
+- name: Immediately remove finalizers on {{ anarchy_subject_name }} if never provisioned
+  when: vars.anarchy_subject.status.towerJobs.provision.deployerJob | default('') == ''
+  anarchy_subject_delete:
+    remove_finalizers: true
+
 - name: Schedule destroy {{ anarchy_subject_name }}
+  when: vars.anarchy_subject.status.towerJobs.provision.deployerJob | default('') != ''
   anarchy_schedule_action:
     action: destroy
 ...

--- a/tasks/run-tower-job.yaml
+++ b/tasks/run-tower-job.yaml
@@ -85,7 +85,7 @@
   rescue:
   - name: Tower project update
     awx.awx.tower_project_update:
-      name: "{{ tower_project_name }}"
+      name: "{{ __tower_project_name }}"
       organization: "{{ tower_organization_name }}"
       tower_host: "https://{{ babylon_tower.hostname }}/"
       tower_username: "{{ babylon_tower.user }}"


### PR DESCRIPTION
Our destroy logic requires that an attempt was made to provision the environment. This prevents clean-up of some types of failures. This skips destroy when no provision occurred.