### PR TITLE
Switch to setting callback vars rather than using __meta__

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -20,6 +20,8 @@ tower_job_check_interval: 5m
 # AnarchyGovernor controls __meta__ settings.
 __meta__: "{{ vars.anarchy_governor.vars.job_vars.__meta__ }}"
 
+# Name of variables to set in job vars for the deployer to callback to Anarchy
+# to notify status change, currently just on successful completion.
 callback_url_var: >-
   {{ __meta__.deployer.callback_url_var | default("agnosticd_callback_url") }}
 callback_token_var: >-

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -20,6 +20,11 @@ tower_job_check_interval: 5m
 # AnarchyGovernor controls __meta__ settings.
 __meta__: "{{ vars.anarchy_governor.vars.job_vars.__meta__ }}"
 
+callback_url_var: >-
+  {{ __meta__.deployer.callback_url_var | default("agnosticd_callback_url") }}
+callback_token_var: >-
+  {{ __meta__.deployer.callback_token_var | default("agnosticd_callback_token") }}
+
 tower_organization_name: >-
   {{ __meta__.tower.organization | default('babylon') }}
 tower_inventory_name: >-

--- a/tasks/run-destroy.yaml
+++ b/tasks/run-destroy.yaml
@@ -24,12 +24,8 @@
        | combine(vars.dynamic_job_vars, recursive=True)
        | combine({
          "ACTION": "destroy",
-         "__meta__": {
-           "callback": {
-             "token": anarchy_action_callback_token,
-             "url": anarchy_action_callback_url
-           }
-         }
+         callback_url_var: anarchy_action_callback_url,
+         callback_token_var: anarchy_action_callback_token,
        }, recursive=True)
       }}
   include_tasks:

--- a/tasks/run-provision.yaml
+++ b/tasks/run-provision.yaml
@@ -12,12 +12,8 @@
        | combine(vars.dynamic_job_vars, recursive=True)
        | combine({
          "ACTION": "provision",
-         "__meta__": {
-           "callback": {
-             "token": anarchy_action_callback_token,
-             "url": anarchy_action_callback_url
-           }
-         }
+         callback_url_var: anarchy_action_callback_url,
+         callback_token_var: anarchy_action_callback_token,
        }, recursive=True)
       }}
   include_tasks:

--- a/tasks/run-start.yaml
+++ b/tasks/run-start.yaml
@@ -12,12 +12,8 @@
        | combine(vars.dynamic_job_vars, recursive=True)
        | combine({
          "ACTION": "start",
-         "__meta__": {
-           "callback": {
-             "token": anarchy_action_callback_token,
-             "url": anarchy_action_callback_url
-           }
-         }
+         callback_url_var: anarchy_action_callback_url,
+         callback_token_var: anarchy_action_callback_token,
        }, recursive=True)
       }}
   include_tasks:

--- a/tasks/run-status.yaml
+++ b/tasks/run-status.yaml
@@ -12,12 +12,8 @@
        | combine(vars.dynamic_job_vars, recursive=True)
        | combine({
          "ACTION": "status",
-         "__meta__": {
-           "callback": {
-             "token": anarchy_action_callback_token,
-             "url": anarchy_action_callback_url
-           }
-         }
+         callback_url_var: anarchy_action_callback_url,
+         callback_token_var: anarchy_action_callback_token,
        }, recursive=True)
       }}
   include_tasks:

--- a/tasks/run-stop.yaml
+++ b/tasks/run-stop.yaml
@@ -12,12 +12,8 @@
        | combine(vars.dynamic_job_vars, recursive=True)
        | combine({
          "ACTION": "stop",
-         "__meta__": {
-           "callback": {
-             "token": anarchy_action_callback_token,
-             "url": anarchy_action_callback_url
-           }
-         }
+         callback_url_var: anarchy_action_callback_url,
+         callback_token_var: anarchy_action_callback_token,
        }, recursive=True)
       }}
   include_tasks:


### PR DESCRIPTION
The `__meta__` vars should not be referenced by the deployer.

In particular, the `__meta__` now can contain Jinja2 message templates that will cause failures in the Ansible deploye if processed as variables. A cleaner solution is to pass callback variables directly.

Support for `agnosticd_callback_url` and `agnosticd_callback_token` were added a while ago to AgnosticD to support integration with the guid-grabber application. This leverages that same mechanism to directly set these variables while also introducing a mechanism to configure variables for other deployers.