### PR TITLE
Add 'update' action

### DIFF
--- a/tasks/check-deployer-job.yaml
+++ b/tasks/check-deployer-job.yaml
@@ -76,24 +76,24 @@
     anarchy_finish_action:
       state: failed
 
-- name: Handle tower job success (when no callback received)
-vars:
-  __job_status: "{{ r_api_response.json.status }}"
-  __job_name: "{{ r_api_response.json.name | default('UNKNOWN') }}"
-when: __job_status in ['successful']
-block:
+- name: Handle tower job success when no callback received
+  vars:
+    __job_status: "{{ r_api_response.json.status }}"
+    __job_name: "{{ r_api_response.json.name | default('UNKNOWN') }}"
+  when: __job_status in ['successful']
+  block:
 
-  - name: Notification message
-    debug:
-      msg:
-        - "No callback received for successful job: {{ __job_name }}"
+    - name: Notification message
+      debug:
+        msg:
+          - "No callback received for successful job: {{ __job_name }}"
 
-  - name: Handle action complete for {{ anarchy_subject_name }}
-    include_tasks: >-
-      {%- if anarchy_action_config_name is defined -%}
-      handle-action-{{ anarchy_action_config_name }}-complete.yaml
-      {%- endif -%}
-    ignore_errors: true
+    - name: Handle action complete for {{ anarchy_subject_name }}
+      include_tasks: >-
+        {%- if anarchy_action_config_name is defined -%}
+        handle-action-{{ anarchy_action_config_name }}-complete.yaml
+        {%- endif -%}
+      ignore_errors: true
 
 - name: Schedule next check for {{ tower_job_action }} {{ anarchy_subject_name }}
   vars:

--- a/tasks/check-deployer-job.yaml
+++ b/tasks/check-deployer-job.yaml
@@ -76,8 +76,24 @@
     anarchy_finish_action:
       state: failed
 
-# FIXME - How to handle successful deployment where we did not get the
-#         completion callback?
+- name: Handle tower job success (when no callback received)
+vars:
+  __job_status: "{{ r_api_response.json.status }}"
+  __job_name: "{{ r_api_response.json.name | default('UNKNOWN') }}"
+when: __job_status in ['successful']
+block:
+
+  - name: Notification message
+    debug:
+      msg:
+        - "No callback received for successful job: {{ __job_name }}"
+
+  - name: Handle action complete for {{ anarchy_subject_name }}
+    include_tasks: >-
+      {%- if anarchy_action_config_name is defined -%}
+      handle-action-{{ anarchy_action_config_name }}-complete.yaml
+      {%- endif -%}
+    ignore_errors: true
 
 - name: Schedule next check for {{ tower_job_action }} {{ anarchy_subject_name }}
   vars:

--- a/tasks/check-deployer-job.yaml
+++ b/tasks/check-deployer-job.yaml
@@ -93,7 +93,6 @@
         {%- if anarchy_action_config_name is defined -%}
         handle-action-{{ anarchy_action_config_name }}-complete.yaml
         {%- endif -%}
-      ignore_errors: true
 
 - name: Schedule next check for {{ tower_job_action }} {{ anarchy_subject_name }}
   vars:

--- a/tasks/handle-action-update-complete.yaml
+++ b/tasks/handle-action-update-complete.yaml
@@ -1,0 +1,18 @@
+---
+- name: Set state updated for {{ anarchy_subject_name }}
+  anarchy_subject_update:
+    metadata:
+      labels:
+        state: started
+    spec:
+      vars:
+        current_state: started
+    status:
+      towerJobs:
+        start:
+          completeTimestamp: '{{ anarchy_run_timestamp }}'
+
+- name: Report action successful
+  anarchy_finish_action:
+    state: successful
+...

--- a/tasks/handle-action-update.yaml
+++ b/tasks/handle-action-update.yaml
@@ -1,0 +1,12 @@
+---
+- name: Update {{ anarchy_subject_name }}
+  when: current_state == "update-pending"
+  include_tasks: run-update.yaml
+
+- name: Check start of {{ anarchy_subject_name }}
+  when: current_state == "updating"
+  vars:
+    tower_job_action: update
+    tower_job_info: "{{ vars['anarchy_subject']['status']['towerJobs']['update'] }}"
+  include_tasks: check-deployer-job.yaml
+...

--- a/tasks/handle-event-update.yaml
+++ b/tasks/handle-event-update.yaml
@@ -3,11 +3,16 @@
   vars:
     _current_state: "{{ current_state | default('unknown') }}"
     _desired_state: "{{ desired_state | default('unknown') }}"
+    _current_job_vars: "{{ vars.anarchy_subject.spec.vars.job_vars | default('unknown') }}"
+    _previous_job_vars: "{{ vars.anarchy_subject_previous_state.spec.vars.job_vars | default(_current_job_vars) }}"
     _action: >-
-      {{ 'provision' if _current_state == 'new' else
-         'start' if (_current_state == 'stopped' and _desired_state == 'started') else
-         'stop' if (_current_state == 'started' and _desired_state == 'stopped') else
-         'no action' }}
+      {{
+        'provision' if _current_state == 'new' else
+        'update' if _current_job_vars != _previous_job_vars else
+        'start' if (_current_state == 'stopped' and _desired_state == 'started') else
+        'stop' if (_current_state == 'started' and _desired_state == 'stopped') else
+        'no action'
+      }}
   when: _action != 'no action'
   block:
   - name: Set {{ anarchy_subject_name }} current state to {{ _action }}-pending

--- a/tasks/run-tower-job.yaml
+++ b/tasks/run-tower-job.yaml
@@ -140,7 +140,7 @@
              "startTimestamp": anarchy_run_timestamp,
              "completeTimestamp": None,
              "towerHost": babylon_tower.hostname,
-             "towerJobURL": tower_host ~ "#/jobs/" ~ r_launch_job.id ~ "/"
+             "towerJobURL": babylon_tower.hostname ~ "#/jobs/" ~ r_launch_job.id ~ "/"
            }
         } }}
 ...

--- a/tasks/run-update.yaml
+++ b/tasks/run-update.yaml
@@ -1,0 +1,25 @@
+---
+- name: Run deployer update {{ anarchy_subject_name }}
+  vars:
+    new_subject_state: updating
+    tower_job_template_playbook: >-
+      {{ vars['anarchy_governor']['vars']['job_vars']['__meta__']['deployer']['entry_points']['update']
+       | default(vars.anarchy_governor.vars.job_vars.__meta__.deployer.entry_point)
+       | default('ansible/update.yml') }}
+    tower_job_extra_vars: >-
+      {{ vars.anarchy_subject.vars.job_vars | default({})
+       | combine(vars.anarchy_governor.vars.job_vars, recursive=True)
+       | combine(vars.dynamic_job_vars, recursive=True)
+       | combine({
+         "ACTION": "update",
+         callback_url_var: anarchy_action_callback_url,
+         callback_token_var: anarchy_action_callback_token,
+       }, recursive=True)
+      }}
+  include_tasks:
+    file: run-tower-job.yaml
+
+- name: Schedule check for update of {{ anarchy_subject_name }}
+  anarchy_continue_action:
+    after: "{{ tower_job_check_interval }}"
+...

--- a/tests/test-action-update.yaml
+++ b/tests/test-action-update.yaml
@@ -1,0 +1,124 @@
+---
+- name: test-action-update
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    anarchy_governor:
+      spec:
+        # Vars in the spec are not yet processed
+        vars:
+          job_vars:
+            aws_region: us-east-1
+            test_late_eval: "{{ late_eval }}"
+        varSecrets:
+        - name: aws
+          namespace: foo
+          var: job_vars
+      # vars at this level are processed vars injected by Anarchy...
+      vars:
+        job_vars:
+          aws_region: us-east-1
+          governor_var: good
+          governor_override_var: good
+          test_late_eval: "{{ late_eval }}"
+    anarchy_subject:
+      vars:
+        job_vars:
+          subject_var: good
+          governor_override_var: bad
+    anarchy_subject_name: test
+    anarchy_action_name: test
+    anarchy_action_config_name: update
+    anarchy_action_callback_url: test
+    anarchy_action_callback_token: test
+    anarchy_run_timestamp: 2020-01-01T00:00:00Z
+    babylon_tower:
+      hostname: test
+      user: test
+      password: test
+
+  pre_tasks:
+  - name: Create test output dir
+    tempfile:
+      state: directory
+    register: r_test_output_dir
+  - name: Set test_output_dir
+    set_fact:
+      test_output_dir: "{{ r_test_output_dir.path }}"
+
+  roles:
+  - role: babylon_anarchy_governor
+
+  post_tasks:
+  - name: Test output data
+    set_fact:
+      anarchy_subject_updates: >-
+        {{ lookup('file', test_output_dir ~ '/anarchy_subject_updates.yaml') | from_yaml }}
+      uri_calls: >-
+        {{ lookup('file', test_output_dir ~ '/uri-calls.yaml') | from_yaml }}
+
+  - debug:
+      var: uri_calls
+  - name: Check that update was scheduled
+    assert:
+      that:
+      - uri_calls == expected
+      msg: Action update was not scheduled as expected
+    vars:
+      expected:
+      - body:
+          extra_vars:
+            job_vars:
+              ACTION: update
+              __meta__:
+                callback:
+                  token: test
+                  url: test
+                deployer:
+                  entry_point: ansible/main.yml
+                  timeout: 0
+                tower:
+                  action: update
+              aws_region: us-east-1
+              governor_override_var: good
+              governor_var: good
+              subject_var: good
+              test_late_eval: "{% raw %}{{ late_eval }}{% endraw %}"
+        body_format: json
+        force_basic_auth: true
+        method: POST
+        return_content: true
+        status_code: 201
+        url: https://test/api/v2/job_templates/job-runner/launch/
+        url_password: test
+        url_username: test
+        validate_certs: false
+
+  - debug:
+      var: anarchy_subject_updates
+  - name: Check anarchy_subject_updates
+    assert:
+      that:
+      - anarchy_subject_updates == expected
+      msg: anarchy_subject_update was not called as expected
+    vars:
+      expected:
+      - spec:
+          vars:
+            dynamic_job_vars:
+              aws_region: us-east-1
+          varSecrets:
+          - name: aws
+            namespace: foo
+            var: dynamic_job_vars
+        status:
+          towerJobs:
+            update:
+              launchJob: ""
+              launchTimestamp: "2020-01-01 00:00:00+00:00"
+
+  - name: Remove test_output_dir
+    file:
+      path: "{{ test_output_dir }}"
+      state: absent

--- a/tests/test.yaml
+++ b/tests/test.yaml
@@ -10,6 +10,7 @@
 - import_playbook: test-action-provision-complete-noaction.yaml
 - import_playbook: test-action-provision-complete-schedule-stop.yaml
 - import_playbook: test-action-provision-complete-schedule-destroy.yaml
+- import_playbook: test-action-update.yaml
 - import_playbook: test-action-start.yaml
 - import_playbook: test-action-start-started.yaml
 - import_playbook: test-action-start-complete-noaction.yaml


### PR DESCRIPTION
## Overview

- Adds a new action of 'update' based on if the current job_vars are not the same as prior job_vars.
- Defaults to the same as the current job vars if previous job_vars is not defined such as on a first-time run.

## To Do

- [x] Test [debug](https://github.com/MAHDTech/babylon_anarchy_governor/blob/1863e142b0031d11335dfdf7887c9c3419e8eefd/tasks/handle-event-update.yaml#L3) message to determine vars are populated
- [x] Determine any additional places that need to be updated to reflect the action
- [x] Test using separate ResourceClaim objects as per existing LodeStar orchestration backend
- [x] Test by patching the existing ResourceClaim object and see if execution is triggered
- [x] Remove debug messages
- [x] Check for leftover TODO items
- [x] Place in review
- [x] Incorporate feedback
  - [x] Add missing task file
  - [x] Use supported current_state of 'started'
  - [x] Test with successful callback
  - [x] Test handle missing callback
- [x] Rebase on main and test with latest changes
- [x] Correct empty variable tower_host
