### PR TITLE
Change current job_vars path

### DIFF
--- a/tasks/handle-event-update.yaml
+++ b/tasks/handle-event-update.yaml
@@ -3,8 +3,8 @@
   vars:
     _current_state: "{{ current_state | default('unknown') }}"
     _desired_state: "{{ desired_state | default('unknown') }}"
-    _current_job_vars: "{{ vars.job_vars | default('unknown') }}"
-    _previous_job_vars: "{{ vars.anarchy_subject_previous_state.spec.vars.job_vars | default(_current_job_vars) }}"
+    _current_job_vars: "{{ vars.anarchy_subject.spec.vars.job_vars | default('unknown') }}"
+    _previous_job_vars: "{{ vars.anarchy_subject_previous_state.spec.vars.job_vars | default_('unknown') }}"
     _action: >-
       {{
         'provision' if _current_state == 'new' else

--- a/tasks/handle-event-update.yaml
+++ b/tasks/handle-event-update.yaml
@@ -3,7 +3,7 @@
   vars:
     _current_state: "{{ current_state | default('unknown') }}"
     _desired_state: "{{ desired_state | default('unknown') }}"
-    _current_job_vars: "{{ vars.anarchy_subject.spec.vars.job_vars | default('unknown') }}"
+    _current_job_vars: "{{ vars.job_vars | default('unknown') }}"
     _previous_job_vars: "{{ vars.anarchy_subject_previous_state.spec.vars.job_vars | default(_current_job_vars) }}"
     _action: >-
       {{


### PR DESCRIPTION
# Overview

Updates the variable that contains the current job vars for comparison with previous job vars during an update operation.

## Example AnarchyRun object snippet

```yaml
apiVersion: anarchy.gpte.redhat.com/v1
kind: AnarchyRun
spec:
  vars:
    anarchy_event_name: update
    anarchy_subject_previous_state:
      spec:
        vars:
          job_vars:
            example: "Previous job vars"
    job_vars:
      example: "Current job vars"
```