### PR TITLE
Fix flag to indicate status check requested

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -6,6 +6,9 @@ delete_on_failure: true
 
 current_state: unknown
 desired_state: unknown
+check_status_request_timestamp: ''
+last_check_status_request_timestamp: >-
+  {{ vars.anarchy_subject_previous_state.spec.vars.check_status_request_timestamp | default('') }}
 check_status_state: null
 
 dynamic_job_vars: {}

--- a/tasks/handle-event-update.yaml
+++ b/tasks/handle-event-update.yaml
@@ -32,8 +32,13 @@
       action: "{{ _action }}"
 
 - name: Schedule status action if check pending
+  # Status check should be requested by setting the check_status_request_timestamp
+  # Legacy support for requesting status by setting check_status_state to pending
   when: >-
-    (check_status_state == 'requested' or check_status_state == 'pending')
+    (check_status_state == 'pending' or (
+      check_status_request_timestamp != last_check_status_request_timestamp and
+      check_status_state in ['', 'successful']
+    )) and
     'status' in vars.anarchy_governor.spec.actions and
     deployer_entry_points.status | default('', true) != ''
   block:


### PR DESCRIPTION
Start status check action on both `requested` and `pending` for compatibility. Later switch to only start on `requested`.