### PR TITLE
Add __meta__.deployer.actions support

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -64,34 +64,48 @@ execution_environment: >-
   | default({}) }}
   {%- endif -%}
 
+# Gather entry points for actions.
+# If disable is set for action then default entry point to empty string.
 deployer_entry_points:
   destroy: >-
-    {{ __meta__.deployer.entry_points.destroy
+    {{ __meta__.deployer.actions.destroy.disable | default(false) | bool | ternary('',
+     __meta__.deployer.actions.destroy.entry_point
+     | default(__meta__.deployer.entry_points.destroy)
      | default(__meta__.deployer.entry_point)
      | default('ansible/destroy.yml')
-    }}
+    )}}
+  # Note, provision entry point cannot be disabled.
   provision: >-
-    {{ __meta__.deployer.entry_points.provision
+    {{ __meta__.deployer.actions.provision.entry_point
+     | default(__meta__.deployer.entry_points.provision)
      | default(__meta__.deployer.entry_point)
      | default('ansible/main.yml')
     }}
   start: >-
-    {{ __meta__.deployer.entry_points.start
+    {{ __meta__.deployer.actions.start.disable | default(false) | bool | ternary('',
+     __meta__.deployer.actions.start.entry_point
+     | default(__meta__.deployer.entry_points.start)
      | default(__meta__.deployer.entry_point)
      | default('ansible/lifecycle_entry_point.yml')
-    }}
+    )}}
   status: >-
-    {{ __meta__.deployer.entry_points.status
+    {{ __meta__.deployer.actions.status.disable | default(false) | bool | ternary('',
+     __meta__.deployer.actions.status.entry_point
+     | default(__meta__.deployer.entry_points.status)
      | default(__meta__.deployer.entry_point)
      | default('ansible/lifecycle_entry_point.yml')
-    }}
+    )}}
   stop: >-
-    {{ __meta__.deployer.entry_points.stop
+    {{ __meta__.deployer.actions.stop.disable | default(false) | bool | ternary('',
+     __meta__.deployer.actions.stop.entry_point
+     | default(__meta__.deployer.entry_points.stop)
      | default(__meta__.deployer.entry_point)
      | default('ansible/lifecycle_entry_point.yml')
-    }}
+    )}}
   update: >-
-    {{ __meta__.deployer.entry_points['update']
+    {{ __meta__.deployer.actions.stop.disable | default(false) | bool | ternary('',
+     __meta__.deployer.actions['update'].entry_point
+     | default(__meta__.deployer.entry_points['update'])
      | default(__meta__.deployer.entry_point)
      | default('ansible/update.yml')
-    }}
+    )}}

--- a/tasks/run-destroy.yaml
+++ b/tasks/run-destroy.yaml
@@ -19,8 +19,8 @@
       {{ vars.anarchy_subject.vars.job_vars | default({})
        | combine(vars.anarchy_governor.vars.job_vars, recursive=True)
        | combine(vars.dynamic_job_vars, recursive=True)
+       | combine(__meta__.deployer.actions.destroy.extra_vars | default({"ACTION": "destroy"}))
        | combine({
-         "ACTION": "destroy",
          callback_url_var: anarchy_action_callback_url,
          callback_token_var: anarchy_action_callback_token,
        }, recursive=True)

--- a/tasks/run-provision.yaml
+++ b/tasks/run-provision.yaml
@@ -7,8 +7,8 @@
       {{ vars.anarchy_subject.vars.job_vars | default({})
        | combine(vars.anarchy_governor.vars.job_vars, recursive=True)
        | combine(vars.dynamic_job_vars, recursive=True)
+       | combine(__meta__.deployer.actions.provision.extra_vars | default({"ACTION": "provision"}))
        | combine({
-         "ACTION": "provision",
          callback_url_var: anarchy_action_callback_url,
          callback_token_var: anarchy_action_callback_token,
        }, recursive=True)

--- a/tasks/run-start.yaml
+++ b/tasks/run-start.yaml
@@ -7,8 +7,8 @@
       {{ vars.anarchy_subject.vars.job_vars | default({})
        | combine(vars.anarchy_governor.vars.job_vars, recursive=True)
        | combine(vars.dynamic_job_vars, recursive=True)
+       | combine(__meta__.deployer.actions.start.extra_vars | default({"ACTION": "start"}))
        | combine({
-         "ACTION": "start",
          callback_url_var: anarchy_action_callback_url,
          callback_token_var: anarchy_action_callback_token,
        }, recursive=True)

--- a/tasks/run-status.yaml
+++ b/tasks/run-status.yaml
@@ -7,8 +7,8 @@
       {{ vars.anarchy_subject.vars.job_vars | default({})
        | combine(vars.anarchy_governor.vars.job_vars, recursive=True)
        | combine(vars.dynamic_job_vars, recursive=True)
+       | combine(__meta__.deployer.actions.status.extra_vars | default({"ACTION": "status"}))
        | combine({
-         "ACTION": "status",
          callback_url_var: anarchy_action_callback_url,
          callback_token_var: anarchy_action_callback_token,
        }, recursive=True)

--- a/tasks/run-stop.yaml
+++ b/tasks/run-stop.yaml
@@ -7,8 +7,8 @@
       {{ vars.anarchy_subject.vars.job_vars | default({})
        | combine(vars.anarchy_governor.vars.job_vars, recursive=True)
        | combine(vars.dynamic_job_vars, recursive=True)
+       | combine(__meta__.deployer.actions.stop.extra_vars | default({"ACTION": "stop"}))
        | combine({
-         "ACTION": "stop",
          callback_url_var: anarchy_action_callback_url,
          callback_token_var: anarchy_action_callback_token,
        }, recursive=True)

--- a/tasks/run-update.yaml
+++ b/tasks/run-update.yaml
@@ -7,8 +7,8 @@
       {{ vars.anarchy_subject.vars.job_vars | default({})
        | combine(vars.anarchy_governor.vars.job_vars, recursive=True)
        | combine(vars.dynamic_job_vars, recursive=True)
+       | combine(__meta__.deployer.actions.update.extra_vars | default({"ACTION": "update"}))
        | combine({
-         "ACTION": "update",
          callback_url_var: anarchy_action_callback_url,
          callback_token_var: anarchy_action_callback_token,
        }, recursive=True)


### PR DESCRIPTION
Retain support for deprecated `__meta__.deployer.entry_points` and `__meta__.deployer.entry_point`.