### PR TITLE
Adding virtualenv absolute path configuration

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -51,7 +51,11 @@ tower_job_template_timeout: >-
 tower_job_template_custom_virtualenv: >-
   {%- if ansible_control_plane == 'tower' and
   __meta__.deployer.virtualenv | default('') != '' -%}
-  {{ tower_job_template_custom_virtualenv_basedir }}/{{ __meta__.deployer.virtualenv }}
+    {%- if __meta__.deployer.virtualenv.startswith('/') -%}
+      {{ __meta__.deployer.virtualenv }}
+    {%- else -%}
+      {{ tower_job_template_custom_virtualenv_basedir }}/{{ __meta__.deployer.virtualenv }}
+    {%- endif -%}
   {%- endif -%}
 
 tower_job_template_custom_virtualenv_basedir: /opt/rh/virtualenvs


### PR DESCRIPTION
This change will add check for the absolute path for `__meta__.deployer.virtualenv` variable. 

If `__meta__.deployer.virtualenv` started with `/` then it's a absolute path and will be assigned to `tower_job_template_custom_virtualenv` as-is. 

Otherwise it's just virtual environment name and full path will be generated like `{{ tower_job_template_custom_virtualenv_basedir }}/{{ __meta__.deployer.virtualenv }}`
