### PR TITLE
Remove "new" state in favor of provisioning from create

### DIFF
--- a/tasks/handle-event-create.yaml
+++ b/tasks/handle-event-create.yaml
@@ -1,13 +1,19 @@
 ---
-- name: Set {{ anarchy_subject_name }} current state to new
+- name: Set {{ anarchy_subject_name }} current state to provision-pending
+  when: vars.anarchy_subject.spec.vars.current_state is undefined
   anarchy_subject_update:
+    skip_update_processing: true
     metadata:
       labels:
-        state: new
+        state: provision-pending
     spec:
       vars:
-        current_state: new
+        current_state: provision-pending
         job_vars:
           uuid: >-
-            {{ vars.anarchy_subject.vars.job_vars.uuid | default((2**127) | random | to_uuid) }}
+            {{ vars.anarchy_subject.spec.vars.job_vars.uuid | default((2**127) | random | to_uuid) }}
+
+- name: Schedule provision for {{ anarchy_subject_name }}
+  anarchy_schedule_action:
+    action: provision
 ...

--- a/tasks/handle-event-update.yaml
+++ b/tasks/handle-event-update.yaml
@@ -7,7 +7,6 @@
     _previous_job_vars: "{{ vars.anarchy_subject_previous_state.spec.vars.job_vars | default(_current_job_vars) }}"
     _action: >-
       {{
-        'provision' if _current_state == 'new' else
         'update' if _current_job_vars != _previous_job_vars else
         'start' if (_current_state == 'stopped' and _desired_state == 'started') else
         'stop' if (_current_state == 'started' and _desired_state == 'stopped') else


### PR DESCRIPTION
Improves efficiency of Anarchy processing by removing an "update" run and adds check to prevent double provision.