### PR TITLE
feat: add queue handling for sandbox placements

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -208,6 +208,7 @@ sandbox_api_url: >-
   | default('http://sandbox-api.babylon-sandbox-api.svc.cluster.local:8080') }}
 sandbox_api_retries: 40
 sandbox_api_delay: 5
+sandbox_api_queue_check_interval: 30s
 
 now_time_utc: "{{ now(utc=true, fmt='%FT%TZ') }}"
 

--- a/tasks/check-provision-queue.yaml
+++ b/tasks/check-provision-queue.yaml
@@ -1,0 +1,86 @@
+---
+- include_tasks: sandbox_api_login.yaml
+
+- name: Check placement status for queued {{ anarchy_subject_name }}
+  uri:
+    headers:
+      Authorization: Bearer {{ access_token }}
+    url: "{{ sandbox_api_url }}/api/v1/placements/{{ uuid }}"
+    method: GET
+    status_code: [200, 404]
+  register: r_check_placement
+  retries: "{{ sandbox_api_retries }}"
+  delay: "{{ sandbox_api_delay }}"
+  until: >-
+    r_check_placement.json.status | default('unknown') in ['success', 'error', 'queued']
+    or r_check_placement.json.http_code == 404
+  changed_when: false
+
+- name: Handle placement error for {{ anarchy_subject_name }}
+  when: >-
+    r_check_placement.json.status | default('unknown') == 'error'
+    or r_check_placement.status | default(0) == 404
+  block:
+  - name: Debug placement error
+    debug:
+      var: r_check_placement
+
+  - name: Finish action {{ anarchy_action_name }} as failed
+    include_tasks:
+      file: handle-action-provision-error.yaml
+
+  - meta: end_play
+
+- name: Handle placement still queued for {{ anarchy_subject_name }}
+  when: r_check_placement.json.status | default('unknown') == 'queued'
+  block:
+  - name: Update queue status for {{ anarchy_subject_name }}
+    anarchy_subject_update:
+      skip_update_processing: true
+      status:
+        sandboxAPIJobs:
+          provision:
+            placementStatus: queued
+            lastCheckTimestamp: "{{ now_time_utc }}"
+
+  - name: Schedule re-check for queued placement {{ anarchy_subject_name }}
+    anarchy_continue_action:
+      after: "{{ sandbox_api_queue_check_interval }}"
+
+  - meta: end_play
+
+# Placement is ready (status == 'success'), proceed with normal provisioning
+- name: Resume provisioning for {{ anarchy_subject_name }}
+  when: r_check_placement.json.status | default('unknown') == 'success'
+  block:
+  - name: Inject vars from dequeued placement into dynamic_job_vars for {{ anarchy_subject_name }}
+    when: r_check_placement.json.resources | default([]) | length > 0
+    set_fact:
+      dynamic_job_vars: >-
+        {{ dynamic_job_vars
+        | default({})
+        | combine(r_check_placement.json | extract_sandboxes_vars, recursive=True) }}
+      extracted_sandboxes_vars: >-
+        {{ r_check_placement.json | extract_sandboxes_vars }}
+
+  - name: Set sandbox and state provision-pending for {{ anarchy_subject_name }}
+    anarchy_subject_update:
+      skip_update_processing: true
+      metadata:
+        labels: >-
+          {{ r_check_placement.json | extract_sandboxes_labels
+          | combine({'state': 'provision-pending'}) }}
+      spec:
+        vars:
+          current_state: provision-pending
+          job_vars: "{{ r_check_placement.json | extract_sandboxes_vars(creds=False) }}"
+      status:
+        sandboxAPIJobs:
+          provision:
+            placementStatus: success
+            dequeuedTimestamp: "{{ now_time_utc }}"
+            httpStatus: "{{ r_check_placement.status }}"
+
+  - name: Run provisioning for dequeued {{ anarchy_subject_name }}
+    include_tasks: run-provision.yaml
+...

--- a/tasks/handle-action-provision.yaml
+++ b/tasks/handle-action-provision.yaml
@@ -4,6 +4,11 @@
     current_state == "provision-pending"
   include_tasks: run-provision.yaml
 
+- name: Check queued provision of {{ anarchy_subject_name }}
+  when: >-
+    current_state == "provision-queued"
+  include_tasks: check-provision-queue.yaml
+
 - name: Check provision of {{ anarchy_subject_name }}
   when: >-
     current_state == "provisioning"

--- a/tasks/sandbox_api_book.yaml
+++ b/tasks/sandbox_api_book.yaml
@@ -74,6 +74,31 @@
 
   - meta: end_play
 
+- name: Handle queued placement for {{ anarchy_subject_name }}
+  when: r_new_placement.json.status | default('') == 'queued'
+  block:
+  - name: Set state provision-queued for {{ anarchy_subject_name }}
+    anarchy_subject_update:
+      skip_update_processing: true
+      metadata:
+        labels:
+          state: provision-queued
+      spec:
+        vars:
+          current_state: provision-queued
+      status:
+        sandboxAPIJobs:
+          provision:
+            startTimestamp: "{{ now_time_utc }}"
+            httpStatus: "{{ r_new_placement.status }}"
+            placementStatus: queued
+
+  - name: Schedule re-check for queued placement {{ anarchy_subject_name }}
+    anarchy_continue_action:
+      after: "{{ sandbox_api_queue_check_interval }}"
+
+  - meta: end_play
+
 - name: Wait for the resources of the placement to be ready
   uri:
     headers:
@@ -84,9 +109,34 @@
   register: r_placement
   retries: "{{ sandbox_api_retries }}"
   delay: "{{ sandbox_api_delay }}"
-  until: r_placement.json.status | default('unknown') in ['success', 'error']
+  until: r_placement.json.status | default('unknown') in ['success', 'error', 'queued']
   changed_when: false
   failed_when: false
+
+- name: Handle late-detected queued placement for {{ anarchy_subject_name }}
+  when: r_placement.json.status | default('unknown') == 'queued'
+  block:
+  - name: Set state provision-queued for {{ anarchy_subject_name }}
+    anarchy_subject_update:
+      skip_update_processing: true
+      metadata:
+        labels:
+          state: provision-queued
+      spec:
+        vars:
+          current_state: provision-queued
+      status:
+        sandboxAPIJobs:
+          provision:
+            startTimestamp: "{{ now_time_utc }}"
+            httpStatus: "{{ r_new_placement.status }}"
+            placementStatus: queued
+
+  - name: Schedule re-check for queued placement {{ anarchy_subject_name }}
+    anarchy_continue_action:
+      after: "{{ sandbox_api_queue_check_interval }}"
+
+  - meta: end_play
 
 - name: Finish action {{ anarchy_action_name }} as failed
   # TODO: ensure it's the right way to finish, question for JK

--- a/tasks/sandbox_api_get.yaml
+++ b/tasks/sandbox_api_get.yaml
@@ -10,7 +10,7 @@
   delay: "{{ sandbox_api_delay }}"
   register: r_get_placement
   until: >-
-    r_get_placement.json.status | default('unknown') in ['success', 'error']
+    r_get_placement.json.status | default('unknown') in ['success', 'error', 'queued']
     or r_get_placement.json.http_code == 404
 
 - name: Finish action {{ anarchy_action_name }} as failed

--- a/tests/action_plugins/anarchy_continue_action.py
+++ b/tests/action_plugins/anarchy_continue_action.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import json
+import os
+from copy import deepcopy
+from ansible.plugins.action import ActionBase
+
+class ActionModule(ActionBase):
+    def run(self, tmp=None, task_vars=None, **_):
+        result = super(ActionModule, self).run(tmp, task_vars)
+        test_output_dir = task_vars.get('test_output_dir', '.')
+        fh = open(os.path.join(test_output_dir, 'anarchy_continue_actions.yaml'), 'a')
+        fh.write('- ' + json.dumps(self._task.args) + '\n')
+        result.update(deepcopy(self._task.args))
+        return result


### PR DESCRIPTION
Add support for handling queued placements from sandbox API.

- Introduce `sandbox_api_queue_check_interval` variable to control how often queued placements are re-checked
- Add new state `provision-queued` to track placements waiting in queue
- Implement periodic checks for queued placements via `anarchy_continue_action`
- Update placement status checks to recognize 'queued' state
- Add test plugin to capture continue action calls for verification