### PR TITLE
feat: normalize boolean values in cloud_selector

### DIFF
--- a/filter_plugins/babylon.py
+++ b/filter_plugins/babylon.py
@@ -106,6 +106,13 @@ def filter_main_sandbox(resources, kind='AwsSandbox'):
     return main_sandbox
 
 
+def _normalize_bool_to_string(value):
+    """Convert a boolean value to 'yes'/'no' string.
+    Non-boolean values are returned as-is."""
+    if isinstance(value, bool):
+        return 'yes' if value else 'no'
+    return value
+
 def inject_var_annotations(sandboxes_request):
     """
     Inject the var key in the annotations of the sandboxes to be able to reference them in the sandboxes_request
@@ -119,6 +126,14 @@ def inject_var_annotations(sandboxes_request):
         if req.get('namespace_suffix', False):
             req['annotations'] = req.get('annotations', {})
             req['annotations']['namespace_suffix'] = req['namespace_suffix']
+
+        # Normalize boolean values in cloud_selector and cloud_preference
+        # to "yes"/"no" strings. YAML parses unquoted true/false as Python
+        # booleans, but the API requires string values.
+        for field in ('cloud_selector', 'cloud_preference'):
+            if field in req:
+                for key in req[field]:
+                    req[field][key] = _normalize_bool_to_string(req[field][key])
 
     return sandboxes_request
 
@@ -168,14 +183,17 @@ def validate_sandboxes_request(sandboxes_request):
                 if not isinstance(req['annotations'][key], str):
                     return "ERROR: Annotations values should be strings for sandbox of kind " + kind
 
-        # Ensure cloud_selector is a dict of string
-        if 'cloud_selector' in req:
-            if not isinstance(req['cloud_selector'], dict):
-                return "ERROR: cloud_selector should be a dict for sandbox of kind " + kind
+        # Ensure cloud_selector and cloud_preference are dicts of string
+        # (booleans are also accepted and will be normalized to "yes"/"no"
+        # by inject_var_annotations)
+        for field in ('cloud_selector', 'cloud_preference'):
+            if field in req:
+                if not isinstance(req[field], dict):
+                    return "ERROR: " + field + " should be a dict for sandbox of kind " + kind
 
-            for key in req['cloud_selector']:
-                if not isinstance(req['cloud_selector'][key], str):
-                    return "ERROR: cloud_selector values should be strings for sandbox of kind " + kind
+                for key in req[field]:
+                    if not isinstance(req[field][key], (str, bool)):
+                        return "ERROR: " + field + " values should be strings for sandbox of kind " + kind
 
     return "OK"
 

--- a/filter_plugins/tests/test_babylon.py
+++ b/filter_plugins/tests/test_babylon.py
@@ -76,6 +76,31 @@ def test_inject_var_annotations():
         assert babylon.inject_var_annotations(testcase['resources']) == testcase['expected']
 
 
+def test_inject_var_annotations_normalizes_cloud_selector_booleans():
+    """cloud_selector boolean values should be converted to yes/no strings."""
+    resources = [
+        {
+            'kind': 'OcpSandbox',
+            'cloud_selector': {
+                'keycloak': True,
+                'hcp': False,
+                'purpose': 'dev',
+            },
+        },
+    ]
+    result = babylon.inject_var_annotations(resources)
+    assert result[0]['cloud_selector']['keycloak'] == 'yes'
+    assert result[0]['cloud_selector']['hcp'] == 'no'
+    assert result[0]['cloud_selector']['purpose'] == 'dev'
+
+
+def test_inject_var_annotations_no_cloud_selector():
+    """Requests without cloud_selector should pass through unchanged."""
+    resources = [{'kind': 'AwsSandbox'}]
+    result = babylon.inject_var_annotations(resources)
+    assert result == [{'kind': 'AwsSandbox'}]
+
+
 def test_validate_sandboxes_request():
     testcases = [
         {
@@ -171,6 +196,41 @@ def test_validate_sandboxes_request():
                 },
             ],
             'expected': "ERROR: Annotations values should be strings for sandbox of kind OcpSandbox",
+        },
+        {
+            'request': [
+                {
+                    'kind': 'OcpSandbox',
+                    'cloud_selector': {
+                        'keycloak': True,
+                        'hcp': False,
+                    },
+                },
+            ],
+            'expected': "OK",
+        },
+        {
+            'request': [
+                {
+                    'kind': 'OcpSandbox',
+                    'cloud_selector': {
+                        'keycloak': True,
+                        'purpose': 'dev',
+                    },
+                },
+            ],
+            'expected': "OK",
+        },
+        {
+            'request': [
+                {
+                    'kind': 'OcpSandbox',
+                    'cloud_selector': {
+                        'purpose': 123,
+                    },
+                },
+            ],
+            'expected': "ERROR: cloud_selector values should be strings for sandbox of kind OcpSandbox",
         },
     ]
 


### PR DESCRIPTION
YAML parses unquoted true/false as Python booleans, but the API requires string values ("yes"/"no"). This change ensures compatibility.

- Add _normalize_bool_to_string() helper function
- Convert boolean values in cloud_selector and cloud_preference to "yes"/"no"
- Update validation to accept both strings and booleans
- Add test cases for boolean normalization