### PR TITLE
Add controller-scheduler integration

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -13,7 +13,7 @@ controller_scheduler_url: >-
   {{ __meta__.controller_scheduler.url | default('') }}
 
 controller_scheduler_api_key: >-
-  {{ controller_scheduler_credentials.api_key | default('') }}
+  {{ controller_scheduler_credentials.cluster_scheduler_api_key_governor | default('') }}
 
 anarchy_governor_job_vars: >-
   {{ lookup('unsafe_var', 'anarchy_governor.spec.vars.job_vars') }}

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -9,6 +9,12 @@ ansible_controller_select_mode: >-
   {{ __meta__.ansible_controller_select_mode
   | default('random') }}
 
+controller_scheduler_url: >-
+  {{ __meta__.controller_scheduler.url | default('') }}
+
+controller_scheduler_api_key: >-
+  {{ controller_scheduler_credentials.api_key | default('') }}
+
 anarchy_governor_job_vars: >-
   {{ lookup('unsafe_var', 'anarchy_governor.spec.vars.job_vars') }}
 

--- a/tasks/check-controller-scheduler.yaml
+++ b/tasks/check-controller-scheduler.yaml
@@ -1,0 +1,52 @@
+---
+- name: Call controller-scheduler evaluate API
+  uri:
+    url: "{{ controller_scheduler_url }}/api/v1/evaluate/controllers"
+    method: POST
+    headers:
+      X-API-Key: "{{ controller_scheduler_api_key }}"
+      Content-Type: application/json
+    body_format: json
+    body:
+      candidates: >-
+        {{ ansible_controllers | json_query('[].{domain: hostname}')
+           | default(omit, true) }}
+      require_labels: >-
+        {{ __meta__.controller_scheduler.require_labels | default(omit) }}
+      prefer_labels: >-
+        {{ __meta__.controller_scheduler.prefer_labels | default(omit) }}
+      instance_group: "{{ anarchy_action_config_name | default(omit) }}"
+    validate_certs: false
+    status_code: 200
+    timeout: 10
+  register: r_scheduler_response
+  retries: 2
+  delay: 3
+  until: r_scheduler_response is successful
+  ignore_errors: true
+
+- name: Setup scheduler-selected controller
+  when:
+    - r_scheduler_response is successful
+    - r_scheduler_response.json.ranked | default([]) | length > 0
+  vars:
+    job_info:
+      towerHost: "{{ r_scheduler_response.json.ranked[0].domain }}"
+  include_tasks: controller-access-facts.yaml
+
+- name: Add scheduler-selected controller to available_controllers for cleanup
+  when: controller is defined
+  set_fact:
+    available_controllers: >-
+      {{ available_controllers + [controller] }}
+
+- name: Log controller-scheduler result
+  debug:
+    msg: >-
+      {%- if controller is defined -%}
+      Controller-scheduler selected: {{ controller.hostname }}
+      (score: {{ r_scheduler_response.json.ranked[0].score }})
+      {%- else -%}
+      Controller-scheduler unavailable or failed.
+      Falling back to existing controller selection.
+      {%- endif -%}

--- a/tasks/check-run-tower-job.yaml
+++ b/tasks/check-run-tower-job.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Select controller via controller-scheduler
-  when: controller_scheduler_url | default('') | length > 0
+  when: controller_scheduler_url | length > 0
   include_tasks: check-controller-scheduler.yaml
 
 - name: Check Available Ansible Controllers

--- a/tasks/check-run-tower-job.yaml
+++ b/tasks/check-run-tower-job.yaml
@@ -1,5 +1,10 @@
 ---
+- name: Select controller via controller-scheduler
+  when: controller_scheduler_url | default('') | length > 0
+  include_tasks: check-controller-scheduler.yaml
+
 - name: Check Available Ansible Controllers
+  when: controller is not defined
   loop: "{{ ansible_controllers }}"
   loop_control:
     loop_var: __controller
@@ -7,7 +12,9 @@
   include_tasks: check-ansible-controller.yaml
 
 - name: Set controller vars
-  when: available_controllers | length > 0
+  when:
+    - controller is not defined
+    - available_controllers | length > 0
   vars:
   set_fact:
     controller: >-


### PR DESCRIPTION
## Summary

- Add `check-controller-scheduler.yaml` task that calls the controller-scheduler API for intelligent controller selection based on real-time Prometheus metrics (capacity, failure rate, availability, pending jobs)
- Modify `check-run-tower-job.yaml` to try scheduler first, fall back to existing selection (random/balance/first-available) when `controller is not defined`
- Add `controller_scheduler_url` and `controller_scheduler_api_key` defaults

## How it works

1. If `controller_scheduler_url` is configured, calls `POST /api/v1/evaluate/controllers`
2. On success, uses the top-ranked controller
3. On failure or empty result, existing selection logic runs as fallback